### PR TITLE
[Doc] Add missing mock import to docs `conf.py`

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -94,6 +94,7 @@ def setup(app):
 
 # Mock out external dependencies here, otherwise the autodoc pages may be blank.
 autodoc_mock_imports = [
+    "aiohttp",
     "cpuinfo",
     "torch",
     "transformers",


### PR DESCRIPTION
Fixes the issue identified in https://github.com/vllm-project/vllm/pull/6600#issuecomment-2252739458